### PR TITLE
Fix #23: parallelize diagram generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/mishankov/plantuml-watch-server/ci.yml)](https://github.com/mishankov/plantuml-watch-server/actions/workflows/ci.yml)
 
-This tool makes it easy to see changes in PlantUML files in real-time. It watches for changes in PlantUML files in a specified directory and generates SVG files for them. The generated SVG files are updated live in the browser.
+This tool makes it easy to see changes in PlantUML files in real-time. It watches for changes in PlantUML files in a specified directory and generates SVG and PNG files for them. The generated SVG files are updated live in the browser.
 
 ## Screenshots
 
@@ -60,12 +60,14 @@ Run the executable with the command line options below.
   Specifies the target directory for generated outputs. Default: `output`.
 - `-port [number]`  
   Specifies the port number for the HTTP server. Default: `8080`.
+- `-parallelism [number]`  
+  Specifies the maximum number of diagrams rendered concurrently. Default: the number of CPU cores.
 - `-h`  
   Prints the help message.
 
 Example:
 ```bash
-plantuml-watch-server -plantumlPath="/path/to/plantuml.jar" -input="./diagrams" -output="./output" -port=8080
+plantuml-watch-server -plantumlPath="/path/to/plantuml.jar" -input="./diagrams" -output="./output" -port=8080 -parallelism=4
 ```
 
 ### Docker

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,10 @@ package config
 
 import (
 	"flag"
+	"fmt"
+	"os"
 	"path/filepath"
+	"runtime"
 )
 
 type Config struct {
@@ -10,15 +13,29 @@ type Config struct {
 	InputFolder  string
 	OutputFolder string
 	Port         int
+	Parallelism  int
 }
 
 func NewFromCLIArgs() (*Config, error) {
-	plantUMLPath := flag.String("plantumlPath", "plantuml.jar", "path to plantuml.jar")
-	inputFolder := flag.String("input", "input", "input folder")
-	outputFolder := flag.String("output", "output", "output folder")
-	port := flag.Int("port", 8080, "server port")
+	return NewFromArgs(os.Args[1:])
+}
 
-	flag.Parse()
+func NewFromArgs(args []string) (*Config, error) {
+	flags := flag.NewFlagSet("plantuml-watch-server", flag.ContinueOnError)
+
+	plantUMLPath := flags.String("plantumlPath", "plantuml.jar", "path to plantuml.jar")
+	inputFolder := flags.String("input", "input", "input folder")
+	outputFolder := flags.String("output", "output", "output folder")
+	port := flags.Int("port", 8080, "server port")
+	parallelism := flags.Int("parallelism", runtime.NumCPU(), "maximum number of diagrams to render in parallel")
+
+	if err := flags.Parse(args); err != nil {
+		return nil, err
+	}
+
+	if *parallelism < 1 {
+		return nil, fmt.Errorf("parallelism must be at least 1")
+	}
 
 	inputFolderStr, err := filepath.Abs(*inputFolder)
 	if err != nil {
@@ -35,5 +52,6 @@ func NewFromCLIArgs() (*Config, error) {
 		InputFolder:  inputFolderStr,
 		OutputFolder: outputFolderStr,
 		Port:         *port,
+		Parallelism:  *parallelism,
 	}, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestNewFromArgsUsesDefaultParallelism(t *testing.T) {
+	cfg, err := NewFromArgs(nil)
+	if err != nil {
+		t.Fatalf("NewFromArgs returned error: %v", err)
+	}
+
+	if cfg.Parallelism != runtime.NumCPU() {
+		t.Fatalf("expected parallelism %d, got %d", runtime.NumCPU(), cfg.Parallelism)
+	}
+}
+
+func TestNewFromArgsRejectsInvalidParallelism(t *testing.T) {
+	testCases := [][]string{
+		{"-parallelism=0"},
+		{"-parallelism=-1"},
+	}
+
+	for _, args := range testCases {
+		if _, err := NewFromArgs(args); err == nil {
+			t.Fatalf("expected error for args %v", args)
+		}
+	}
+}

--- a/inputwatcher/inputwatcher.go
+++ b/inputwatcher/inputwatcher.go
@@ -2,6 +2,7 @@ package inputwatcher
 
 import (
 	"context"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -10,9 +11,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mishankov/plantuml-watch-server/plantuml"
 	"github.com/platforma-dev/platforma/log"
 )
+
+type Renderer interface {
+	Render(ctx context.Context, input, output string)
+}
 
 func WatchFile(ctx context.Context, filePath string) error {
 	initialStat, err := os.Stat(filePath)
@@ -41,20 +45,30 @@ func WatchFile(ctx context.Context, filePath string) error {
 }
 
 type InputWatcher struct {
-	inputPath  string
-	outputPath string
-	pulm       *plantuml.PlantUML
+	inputPath     string
+	outputPath    string
+	renderer      Renderer
+	renderSlots   chan struct{}
+	pollInterval  time.Duration
+	watchFileFunc func(ctx context.Context, filePath string) error
 	// Maps .puml file path to the set of output files (.svg and .png) it generated
 	fileToSvgMap   map[string]map[string]bool
 	fileToSvgMutex sync.RWMutex
 }
 
-func New(inputPath, outputPath string, pulm *plantuml.PlantUML) *InputWatcher {
+func New(inputPath, outputPath string, renderer Renderer, parallelism int) *InputWatcher {
+	if parallelism < 1 {
+		parallelism = 1
+	}
+
 	return &InputWatcher{
-		inputPath:    inputPath,
-		outputPath:   outputPath,
-		pulm:         pulm,
-		fileToSvgMap: make(map[string]map[string]bool),
+		inputPath:     inputPath,
+		outputPath:    outputPath,
+		renderer:      renderer,
+		renderSlots:   make(chan struct{}, parallelism),
+		pollInterval:  100 * time.Millisecond,
+		watchFileFunc: WatchFile,
+		fileToSvgMap:  make(map[string]map[string]bool),
 	}
 }
 
@@ -73,8 +87,7 @@ func (iw *InputWatcher) calculateOutputDir(ctx context.Context, inputFilePath st
 	return filepath.Join(iw.outputPath, relDir)
 }
 
-// getSvgFilesInDir returns a map of all output files (.svg and .png) in the given directory and its subdirectories
-func (iw *InputWatcher) getSvgFilesInDir(ctx context.Context, dir string) map[string]bool {
+func (iw *InputWatcher) getOutputFilesInDir(ctx context.Context, dir string) map[string]bool {
 	outputFiles := make(map[string]bool)
 	err := filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
@@ -91,52 +104,133 @@ func (iw *InputWatcher) getSvgFilesInDir(ctx context.Context, dir string) map[st
 	return outputFiles
 }
 
-// ExecuteAndTrack executes PlantUML for a file and tracks which SVGs were generated
-func (iw *InputWatcher) ExecuteAndTrack(ctx context.Context, inputFile, outputDir string) {
-	// Get SVG files before execution
-	svgsBefore := iw.getSvgFilesInDir(ctx, outputDir)
+func (iw *InputWatcher) acquireRenderSlot(ctx context.Context) bool {
+	select {
+	case iw.renderSlots <- struct{}{}:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
 
-	// Get modification times of existing SVGs
-	mtimesBefore := make(map[string]time.Time)
-	for svgPath := range svgsBefore {
-		if info, err := os.Stat(svgPath); err == nil {
-			mtimesBefore[svgPath] = info.ModTime()
-		}
+func (iw *InputWatcher) releaseRenderSlot() {
+	<-iw.renderSlots
+}
+
+func (iw *InputWatcher) RenderFiles(ctx context.Context, files []string) {
+	var wg sync.WaitGroup
+
+	for _, file := range files {
+		outputDir := iw.calculateOutputDir(ctx, file)
+
+		wg.Add(1)
+		go func(filePath string, renderOutputDir string) {
+			defer wg.Done()
+			iw.ExecuteAndTrack(ctx, filePath, renderOutputDir)
+		}(file, outputDir)
 	}
 
-	// Execute PlantUML for both SVG and PNG formats
-	iw.pulm.ExecuteWithFormat(ctx, inputFile, outputDir, "svg")
-	iw.pulm.ExecuteWithFormat(ctx, inputFile, outputDir, "png")
+	wg.Wait()
+}
 
-	// Get SVG files after execution
-	svgsAfter := iw.getSvgFilesInDir(ctx, outputDir)
+func moveFile(src, dst string) error {
+	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
+		return err
+	}
 
-	// Determine which SVGs were created or modified by this execution
-	generatedSvgs := make(map[string]bool)
-	for svgPath := range svgsAfter {
-		// New file or modified file
-		if !svgsBefore[svgPath] {
-			generatedSvgs[svgPath] = true
-		} else if info, err := os.Stat(svgPath); err == nil {
-			if beforeTime, exists := mtimesBefore[svgPath]; exists {
-				if info.ModTime().After(beforeTime) {
-					generatedSvgs[svgPath] = true
-				}
-			}
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	}
+
+	source, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+
+	target, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(target, source); err != nil {
+		target.Close()
+		return err
+	}
+
+	if err := target.Close(); err != nil {
+		return err
+	}
+
+	return os.Remove(src)
+}
+
+// ExecuteAndTrack executes PlantUML for a file and tracks which outputs were generated.
+func (iw *InputWatcher) ExecuteAndTrack(ctx context.Context, inputFile, outputDir string) {
+	if !iw.acquireRenderSlot(ctx) {
+		return
+	}
+	defer iw.releaseRenderSlot()
+
+	parentDir := filepath.Dir(outputDir)
+	if err := os.MkdirAll(parentDir, 0755); err != nil {
+		log.ErrorContext(ctx, "failed to prepare output parent directory", "dir", parentDir, "error", err)
+		return
+	}
+
+	tempDir, err := os.MkdirTemp(parentDir, ".render-*")
+	if err != nil {
+		log.ErrorContext(ctx, "failed to create temporary render directory", "dir", parentDir, "error", err)
+		return
+	}
+	defer os.RemoveAll(tempDir)
+
+	iw.renderer.Render(ctx, inputFile, tempDir)
+
+	tempOutputs := iw.getOutputFilesInDir(ctx, tempDir)
+	generatedOutputs := make(map[string]bool)
+
+	for tempPath := range tempOutputs {
+		relPath, err := filepath.Rel(tempDir, tempPath)
+		if err != nil {
+			log.ErrorContext(ctx, "failed to calculate rendered file path", "file", tempPath, "error", err)
+			continue
 		}
+
+		finalPath := filepath.Join(outputDir, relPath)
+		if err := os.MkdirAll(filepath.Dir(finalPath), 0755); err != nil {
+			log.ErrorContext(ctx, "failed to prepare output directory", "dir", filepath.Dir(finalPath), "error", err)
+			continue
+		}
+
+		if err := moveFile(tempPath, finalPath); err != nil {
+			log.ErrorContext(ctx, "failed to move rendered output", "src", tempPath, "dst", finalPath, "error", err)
+			continue
+		}
+
+		generatedOutputs[finalPath] = true
 	}
 
 	// If no output files were detected as generated, fall back to expected naming
-	if len(generatedSvgs) == 0 {
-		// Assume the output files have the same base name as the .puml file
+	if len(generatedOutputs) == 0 {
 		baseName := strings.TrimSuffix(filepath.Base(inputFile), ".puml")
-		expectedSvg := filepath.Join(outputDir, baseName+".svg")
-		expectedPng := filepath.Join(outputDir, baseName+".png")
+		expectedSvg := filepath.Join(tempDir, baseName+".svg")
+		expectedPng := filepath.Join(tempDir, baseName+".png")
 		if _, err := os.Stat(expectedSvg); err == nil {
-			generatedSvgs[expectedSvg] = true
+			finalPath := filepath.Join(outputDir, baseName+".svg")
+			if err := os.MkdirAll(filepath.Dir(finalPath), 0755); err == nil {
+				if err := moveFile(expectedSvg, finalPath); err == nil {
+					generatedOutputs[finalPath] = true
+				}
+			}
 		}
 		if _, err := os.Stat(expectedPng); err == nil {
-			generatedSvgs[expectedPng] = true
+			finalPath := filepath.Join(outputDir, baseName+".png")
+			if err := os.MkdirAll(filepath.Dir(finalPath), 0755); err == nil {
+				if err := moveFile(expectedPng, finalPath); err == nil {
+					generatedOutputs[finalPath] = true
+				}
+			}
 		}
 	}
 
@@ -147,7 +241,7 @@ func (iw *InputWatcher) ExecuteAndTrack(ctx context.Context, inputFile, outputDi
 
 	// Delete output files that are no longer generated
 	for oldSvg := range oldSvgs {
-		if !generatedSvgs[oldSvg] {
+		if !generatedOutputs[oldSvg] {
 			if err := os.Remove(oldSvg); err != nil {
 				if !os.IsNotExist(err) {
 					log.ErrorContext(ctx, "failed to delete orphaned output file", "file", oldSvg, "error", err)
@@ -160,7 +254,7 @@ func (iw *InputWatcher) ExecuteAndTrack(ctx context.Context, inputFile, outputDi
 
 	// Update the mapping
 	iw.fileToSvgMutex.Lock()
-	iw.fileToSvgMap[inputFile] = generatedSvgs
+	iw.fileToSvgMap[inputFile] = generatedOutputs
 	iw.fileToSvgMutex.Unlock()
 }
 
@@ -184,31 +278,43 @@ func (iw *InputWatcher) GetFiles(ctx context.Context) []string {
 	return files
 }
 
+func (iw *InputWatcher) startWatchingFile(ctx context.Context, watchedFile string, watchedOutputDir string) {
+	go func() {
+		for {
+			err := iw.watchFileFunc(ctx, watchedFile)
+			if err != nil {
+				log.ErrorContext(ctx, "stopped watching file", "error", err)
+				break
+			}
+
+			log.InfoContext(ctx, "file changed", "file", watchedFile)
+			iw.ExecuteAndTrack(ctx, watchedFile, watchedOutputDir)
+		}
+	}()
+}
+
 func (iw *InputWatcher) Run(ctx context.Context) error {
-	files := iw.GetFiles(ctx)
-	oldFiles := []string{}
+	oldFiles := iw.GetFiles(ctx)
+	for _, file := range oldFiles {
+		log.InfoContext(ctx, "watching existing file", "file", file)
+		iw.startWatchingFile(ctx, file, iw.calculateOutputDir(ctx, file))
+	}
 
 	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(iw.pollInterval):
+		}
+
+		files := iw.GetFiles(ctx)
+
 		for _, file := range files {
 			if !slices.Contains(oldFiles, file) {
 				log.InfoContext(ctx, "watching new file", "file", file)
 				outputDir := iw.calculateOutputDir(ctx, file)
 				iw.ExecuteAndTrack(ctx, file, outputDir)
-
-				// Fix goroutine closure bug by passing file and outputDir as parameters
-				go func(watchedFile string, watchedOutputDir string) {
-					for {
-						err := WatchFile(ctx, watchedFile)
-						if err != nil {
-							log.ErrorContext(ctx, "stopped watching file", "error", err)
-							break
-						}
-
-						log.InfoContext(ctx, "file changed", "file", watchedFile)
-
-						iw.ExecuteAndTrack(ctx, watchedFile, watchedOutputDir)
-					}
-				}(file, outputDir)
+				iw.startWatchingFile(ctx, file, outputDir)
 			}
 		}
 
@@ -241,13 +347,6 @@ func (iw *InputWatcher) Run(ctx context.Context) error {
 			}
 		}
 
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(100 * time.Millisecond):
-		}
-
 		oldFiles = files
-		files = iw.GetFiles(ctx)
 	}
 }

--- a/inputwatcher/inputwatcher_test.go
+++ b/inputwatcher/inputwatcher_test.go
@@ -1,0 +1,377 @@
+package inputwatcher
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakeRenderer struct {
+	mu            sync.Mutex
+	active        int
+	maxActive     int
+	perFileActive map[string]int
+	perFileMax    map[string]int
+	callCount     map[string]int
+	started       chan string
+	release       <-chan struct{}
+	renderFunc    func(input, output string, call int) error
+}
+
+func newFakeRenderer() *fakeRenderer {
+	return &fakeRenderer{
+		perFileActive: make(map[string]int),
+		perFileMax:    make(map[string]int),
+		callCount:     make(map[string]int),
+	}
+}
+
+func (r *fakeRenderer) Render(ctx context.Context, input, output string) {
+	r.mu.Lock()
+	r.active++
+	if r.active > r.maxActive {
+		r.maxActive = r.active
+	}
+	r.perFileActive[input]++
+	if r.perFileActive[input] > r.perFileMax[input] {
+		r.perFileMax[input] = r.perFileActive[input]
+	}
+	r.callCount[input]++
+	call := r.callCount[input]
+	r.mu.Unlock()
+
+	if r.renderFunc != nil {
+		if err := r.renderFunc(input, output, call); err != nil {
+			panic(err)
+		}
+	}
+
+	if r.started != nil {
+		r.started <- input
+	}
+
+	if r.release != nil {
+		select {
+		case <-r.release:
+		case <-ctx.Done():
+		}
+	}
+
+	r.mu.Lock()
+	r.perFileActive[input]--
+	r.active--
+	r.mu.Unlock()
+}
+
+func createInputFile(t *testing.T, dir, name string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("failed to create input directory: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("@startuml\n@enduml\n"), 0644); err != nil {
+		t.Fatalf("failed to create input file: %v", err)
+	}
+
+	return path
+}
+
+func waitForString(t *testing.T, ch <-chan string, timeout time.Duration) string {
+	t.Helper()
+
+	select {
+	case value := <-ch:
+		return value
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for event")
+		return ""
+	}
+}
+
+func waitForExpectedEvent(t *testing.T, ch <-chan string, timeout time.Duration, expected map[string]bool) {
+	t.Helper()
+
+	deadline := time.After(timeout)
+	for len(expected) > 0 {
+		select {
+		case value := <-ch:
+			if expected[value] {
+				delete(expected, value)
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for events: %v", expected)
+		}
+	}
+}
+
+func assertNoEvent(t *testing.T, ch <-chan string, timeout time.Duration, description string) {
+	t.Helper()
+
+	select {
+	case value := <-ch:
+		t.Fatalf("unexpected %s: %s", description, value)
+	case <-time.After(timeout):
+	}
+}
+
+func TestRenderFilesRespectsParallelism(t *testing.T) {
+	inputDir := t.TempDir()
+	outputDir := t.TempDir()
+	files := []string{
+		createInputFile(t, inputDir, "one.puml"),
+		createInputFile(t, inputDir, "two.puml"),
+		createInputFile(t, inputDir, "nested/three.puml"),
+	}
+
+	release := make(chan struct{})
+	renderer := newFakeRenderer()
+	renderer.started = make(chan string, len(files))
+	renderer.release = release
+	renderer.renderFunc = func(input, output string, call int) error {
+		base := strings.TrimSuffix(filepath.Base(input), ".puml")
+		return os.WriteFile(filepath.Join(output, base+".svg"), []byte(base), 0644)
+	}
+
+	iw := New(inputDir, outputDir, renderer, 2)
+
+	done := make(chan struct{})
+	go func() {
+		iw.RenderFiles(context.Background(), files)
+		close(done)
+	}()
+
+	started := map[string]bool{}
+	for len(started) < 2 {
+		started[waitForString(t, renderer.started, time.Second)] = true
+	}
+	assertNoEvent(t, renderer.started, 100*time.Millisecond, "extra render start beyond parallelism limit")
+
+	close(release)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for RenderFiles to finish")
+	}
+
+	if renderer.maxActive != 2 {
+		t.Fatalf("expected max active renders to be 2, got %d", renderer.maxActive)
+	}
+}
+
+func TestExecuteAndTrackRemovesStaleOutputs(t *testing.T) {
+	inputDir := t.TempDir()
+	outputDir := t.TempDir()
+	inputFile := createInputFile(t, inputDir, "diagram.puml")
+
+	renderer := newFakeRenderer()
+	renderer.renderFunc = func(input, output string, call int) error {
+		base := strings.TrimSuffix(filepath.Base(input), ".puml")
+		if err := os.WriteFile(filepath.Join(output, base+".svg"), []byte("svg"), 0644); err != nil {
+			return err
+		}
+		if call == 1 {
+			if err := os.WriteFile(filepath.Join(output, base+".png"), []byte("png"), 0644); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	iw := New(inputDir, outputDir, renderer, 1)
+	renderOutputDir := filepath.Join(outputDir)
+
+	iw.ExecuteAndTrack(context.Background(), inputFile, renderOutputDir)
+
+	if _, err := os.Stat(filepath.Join(outputDir, "diagram.svg")); err != nil {
+		t.Fatalf("expected svg output after first render: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "diagram.png")); err != nil {
+		t.Fatalf("expected png output after first render: %v", err)
+	}
+
+	iw.ExecuteAndTrack(context.Background(), inputFile, renderOutputDir)
+
+	if _, err := os.Stat(filepath.Join(outputDir, "diagram.svg")); err != nil {
+		t.Fatalf("expected svg output after second render: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outputDir, "diagram.png")); !os.IsNotExist(err) {
+		t.Fatalf("expected stale png output to be removed, got err=%v", err)
+	}
+}
+
+func TestRunWatchesExistingFilesWithoutInitialRender(t *testing.T) {
+	inputDir := t.TempDir()
+	outputDir := t.TempDir()
+	existingFile := createInputFile(t, inputDir, "existing.puml")
+	newFile := filepath.Join(inputDir, "new.puml")
+
+	renderer := newFakeRenderer()
+	renderer.started = make(chan string, 10)
+	renderer.renderFunc = func(input, output string, call int) error {
+		base := strings.TrimSuffix(filepath.Base(input), ".puml")
+		return os.WriteFile(filepath.Join(output, base+".svg"), []byte(base), 0644)
+	}
+
+	iw := New(inputDir, outputDir, renderer, 2)
+	iw.pollInterval = 10 * time.Millisecond
+
+	watchStarted := make(chan string, 10)
+	iw.watchFileFunc = func(ctx context.Context, filePath string) error {
+		watchStarted <- filePath
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- iw.Run(ctx)
+	}()
+
+	if watched := waitForString(t, watchStarted, time.Second); watched != existingFile {
+		t.Fatalf("expected existing file watcher to start first, got %s", watched)
+	}
+
+	assertNoEvent(t, renderer.started, 100*time.Millisecond, "initial render for existing file")
+
+	if err := os.WriteFile(newFile, []byte("@startuml\n@enduml\n"), 0644); err != nil {
+		t.Fatalf("failed to create new file: %v", err)
+	}
+
+	if rendered := waitForString(t, renderer.started, time.Second); rendered != newFile {
+		t.Fatalf("expected new file to render once, got %s", rendered)
+	}
+	if watched := waitForString(t, watchStarted, time.Second); watched != newFile {
+		t.Fatalf("expected new file watcher to start, got %s", watched)
+	}
+
+	cancel()
+
+	select {
+	case err := <-runDone:
+		if err != context.Canceled {
+			t.Fatalf("expected context cancellation, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for watcher to stop")
+	}
+}
+
+func TestRunParallelizesAcrossFilesAndSerializesSameFile(t *testing.T) {
+	inputDir := t.TempDir()
+	outputDir := t.TempDir()
+	fileA := createInputFile(t, inputDir, "a.puml")
+	fileB := createInputFile(t, inputDir, "b.puml")
+
+	releaseRenders := make(chan struct{})
+	renderer := newFakeRenderer()
+	renderer.started = make(chan string, 10)
+	renderer.release = releaseRenders
+	renderer.renderFunc = func(input, output string, call int) error {
+		base := strings.TrimSuffix(filepath.Base(input), ".puml")
+		return os.WriteFile(filepath.Join(output, base+".svg"), []byte(fmt.Sprintf("%s-%d", base, call)), 0644)
+	}
+
+	iw := New(inputDir, outputDir, renderer, 2)
+	iw.pollInterval = 10 * time.Millisecond
+
+	var mu sync.Mutex
+	watchCalls := make(map[string]int)
+	watchEvents := make(chan string, 10)
+	aChange1 := make(chan struct{})
+	aChange2 := make(chan struct{})
+	bChange1 := make(chan struct{})
+
+	iw.watchFileFunc = func(ctx context.Context, filePath string) error {
+		mu.Lock()
+		watchCalls[filePath]++
+		call := watchCalls[filePath]
+		mu.Unlock()
+
+		watchEvents <- fmt.Sprintf("%s#%d", filepath.Base(filePath), call)
+
+		var release <-chan struct{}
+		switch {
+		case filePath == fileA && call == 1:
+			release = aChange1
+		case filePath == fileA && call == 2:
+			release = aChange2
+		case filePath == fileB && call == 1:
+			release = bChange1
+		default:
+			<-ctx.Done()
+			return ctx.Err()
+		}
+
+		select {
+		case <-release:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- iw.Run(ctx)
+	}()
+
+	waitForExpectedEvent(t, watchEvents, time.Second, map[string]bool{
+		"a.puml#1": true,
+		"b.puml#1": true,
+	})
+
+	close(aChange1)
+	close(bChange1)
+
+	waitForExpectedEvent(t, renderer.started, time.Second, map[string]bool{
+		fileA: true,
+		fileB: true,
+	})
+	assertNoEvent(t, watchEvents, 100*time.Millisecond, "second watch cycle for file A while its render is still running")
+
+	close(releaseRenders)
+
+	waitForExpectedEvent(t, watchEvents, time.Second, map[string]bool{
+		"a.puml#2": true,
+	})
+
+	close(aChange2)
+
+	if rendered := waitForString(t, renderer.started, time.Second); rendered != fileA {
+		t.Fatalf("expected second render for file A, got %s", rendered)
+	}
+
+	cancel()
+
+	select {
+	case err := <-runDone:
+		if err != context.Canceled {
+			t.Fatalf("expected context cancellation, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for watcher to stop")
+	}
+
+	if renderer.maxActive != 2 {
+		t.Fatalf("expected max active renders to be 2, got %d", renderer.maxActive)
+	}
+	if renderer.perFileMax[fileA] != 1 {
+		t.Fatalf("expected file A renders to be serialized, got max overlap %d", renderer.perFileMax[fileA])
+	}
+	if renderer.perFileMax[fileB] != 1 {
+		t.Fatalf("expected file B renders to be serialized, got max overlap %d", renderer.perFileMax[fileB])
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,13 +3,10 @@ package main
 import (
 	"context"
 	"embed"
-	"fmt"
 	"html/template"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/mishankov/plantuml-watch-server/config"
@@ -27,21 +24,6 @@ var staticFiles embed.FS
 //go:embed templates
 var templateFiles embed.FS
 
-func calculateOutputDirForFile(ctx context.Context, inputFilePath, inputRoot, outputRoot string) string {
-	relPath, err := filepath.Rel(inputRoot, inputFilePath)
-	if err != nil {
-		log.ErrorContext(ctx, "error calculating relative path", "path", inputFilePath, "error", err)
-		return outputRoot
-	}
-
-	relDir := filepath.Dir(relPath)
-	if relDir == "." {
-		return outputRoot
-	}
-
-	return filepath.Join(outputRoot, relDir)
-}
-
 func main() {
 	ctx := context.Background()
 	app := application.New()
@@ -53,7 +35,7 @@ func main() {
 	}
 
 	puml := plantuml.New(config.PlantUMLPath)
-	iw := inputwatcher.New(config.InputFolder, config.OutputFolder, puml)
+	iw := inputwatcher.New(config.InputFolder, config.OutputFolder, puml, config.Parallelism)
 
 	// Preparing termplates
 	tmpls, err := template.New("").ParseFS(templateFiles, "templates/*.html")
@@ -66,22 +48,7 @@ func main() {
 		// Remove all stale outputs
 		os.RemoveAll(config.OutputFolder + "/")
 
-		// Generate initial SVGs - iterate through each file to preserve structure
-		inputPattern := config.InputFolder + "/**.puml"
-		files, err := filepath.Glob(inputPattern)
-		if err != nil {
-			return fmt.Errorf("Error finding .puml files: %w", err)
-		}
-
-		for _, file := range files {
-			// Skip files prefixed with underscore
-			if strings.HasPrefix(filepath.Base(file), "_") {
-				continue
-			}
-
-			outputDir := calculateOutputDirForFile(ctx, file, config.InputFolder, config.OutputFolder)
-			iw.ExecuteAndTrack(ctx, file, outputDir)
-		}
+		iw.RenderFiles(ctx, iw.GetFiles(ctx))
 		return nil
 	}, application.StartupTaskConfig{Name: "initial generation", AbortOnError: true})
 

--- a/plantuml/plantuml.go
+++ b/plantuml/plantuml.go
@@ -16,6 +16,11 @@ func New(jarPath string) *PlantUML {
 	return &PlantUML{jarPath: jarPath}
 }
 
+func (puml *PlantUML) Render(ctx context.Context, input, output string) {
+	puml.ExecuteWithFormat(ctx, input, output, "svg")
+	puml.ExecuteWithFormat(ctx, input, output, "png")
+}
+
 func (puml *PlantUML) Execute(ctx context.Context, input, output string) {
 	puml.ExecuteWithFormat(ctx, input, output, "svg")
 }


### PR DESCRIPTION
Closes #23

## Summary
- add a configurable `-parallelism` limit for bounded concurrent rendering
- parallelize startup renders and runtime regenerations across different `.puml` files
- isolate each render in a temporary directory before moving outputs into place to keep file tracking safe under concurrency
- avoid double-rendering existing files when the watcher service starts
- add tests for config validation, concurrency limits, runtime serialization, and output cleanup

## Testing
- `go test ./...`
- `go build ./...`

## Code Review
- reviewed the branch diff locally with a correctness-first pass
- fixed the only material regression found during review (`-h` output was suppressed by the new flag parsing helper)
- no remaining blocker findings

## Notes
- SVG and PNG generation remain serialized per input file; parallelism only applies across different source files
- output tracking now uses per-render temporary directories so concurrent renders in the same folder do not race on before/after directory scans