### PR TITLE
deps: bump github.com/platforma-dev/platforma from 0.1.0-alpha.15 to 0.1.0-alpha.23 in the go-dependencies group

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,10 +23,10 @@ docker build -t plantuml-watch-server .
 ### Running
 ```bash
 # Run with default parameters
-go run .
+go run . run
 
 # Run with custom parameters
-go run . -plantumlPath="/path/to/plantuml.jar" -input="./diagrams" -output="./output" -port=8080
+go run . run -plantumlPath="/path/to/plantuml.jar" -input="./diagrams" -output="./output" -port=8080
 
 # Run with Docker
 docker run -d --name plantuml-watch-server -p 8080:8080 -v /path/to/input:/input -v /path/to/output:/output ghcr.io/mishankov/plantuml-watch-server:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ FROM plantuml/plantuml:latest
 WORKDIR /opt
 COPY --from=buildgo /app/plantuml-watch-server /opt/plantuml-watch-server
 EXPOSE 8080
-ENTRYPOINT [ "./plantuml-watch-server", "-input=/input", "-output=/output" ]
+ENTRYPOINT [ "./plantuml-watch-server", "run", "-input=/input", "-output=/output" ]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ PlantUML Watch Server can be run both as a standalone executable or Docker conta
 
 #### Running the Executable
 
-Run the executable with the command line options below.
+Use the `run` command to start the server with the command line options below.
 
 #### Command Line Parameters
 
@@ -61,11 +61,11 @@ Run the executable with the command line options below.
 - `-port [number]`  
   Specifies the port number for the HTTP server. Default: `8080`.
 - `-h`  
-  Prints the help message.
+  Prints the application flag help when used as `plantuml-watch-server run -h`.
 
 Example:
 ```bash
-plantuml-watch-server -plantumlPath="/path/to/plantuml.jar" -input="./diagrams" -output="./output" -port=8080
+plantuml-watch-server run -plantumlPath="/path/to/plantuml.jar" -input="./diagrams" -output="./output" -port=8080
 ```
 
 ### Docker
@@ -89,6 +89,7 @@ Example `compose.yml`:
 services:
   plantuml-watch-server:
     image: ghcr.io/mishankov/plantuml-watch-server:latest
+    command: ["run", "-input=/input", "-output=/output"]
     ports:
       - "8080:8080"
     volumes: 

--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,10 @@
 package config
 
 import (
+	"errors"
 	"flag"
+	"fmt"
+	"os"
 	"path/filepath"
 )
 
@@ -13,12 +16,28 @@ type Config struct {
 }
 
 func NewFromCLIArgs() (*Config, error) {
-	plantUMLPath := flag.String("plantumlPath", "plantuml.jar", "path to plantuml.jar")
-	inputFolder := flag.String("input", "input", "input folder")
-	outputFolder := flag.String("output", "output", "output folder")
-	port := flag.Int("port", 8080, "server port")
+	if len(os.Args) < 3 {
+		return NewFromArgs(nil)
+	}
 
-	flag.Parse()
+	return NewFromArgs(os.Args[2:])
+}
+
+func NewFromArgs(args []string) (*Config, error) {
+	flagSet := flag.NewFlagSet("plantuml-watch-server", flag.ContinueOnError)
+
+	plantUMLPath := flagSet.String("plantumlPath", "plantuml.jar", "path to plantuml.jar")
+	inputFolder := flagSet.String("input", "input", "input folder")
+	outputFolder := flagSet.String("output", "output", "output folder")
+	port := flagSet.Int("port", 8080, "server port")
+
+	if err := flagSet.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil, err
+		}
+
+		return nil, fmt.Errorf("parse flags: %w", err)
+	}
 
 	inputFolderStr, err := filepath.Abs(*inputFolder)
 	if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"errors"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewFromArgsParsesFlagsWithoutSubcommand(t *testing.T) {
+	cfg, err := NewFromArgs([]string{"-input=./in", "-output=./out", "-port=9999"})
+	if err != nil {
+		t.Fatalf("NewFromArgs returned error: %v", err)
+	}
+
+	assertConfigPaths(t, cfg, "./in", "./out")
+	if cfg.Port != 9999 {
+		t.Fatalf("expected port 9999, got %d", cfg.Port)
+	}
+}
+
+func TestNewFromArgsParsesFlagsAfterRun(t *testing.T) {
+	cfg, err := NewFromArgs([]string{"-input=./in", "-output=./out", "-port=9999"})
+	if err != nil {
+		t.Fatalf("NewFromArgs returned error: %v", err)
+	}
+
+	assertConfigPaths(t, cfg, "./in", "./out")
+	if cfg.Port != 9999 {
+		t.Fatalf("expected port 9999, got %d", cfg.Port)
+	}
+}
+
+func TestNewFromCLIArgsParsesFlagsAfterRun(t *testing.T) {
+	originalArgs := os.Args
+	t.Cleanup(func() {
+		os.Args = originalArgs
+	})
+
+	os.Args = []string{"plantuml-watch-server", "run", "-input=./in", "-output=./out", "-port=9999"}
+
+	cfg, err := NewFromCLIArgs()
+	if err != nil {
+		t.Fatalf("NewFromCLIArgs returned error: %v", err)
+	}
+
+	assertConfigPaths(t, cfg, "./in", "./out")
+	if cfg.Port != 9999 {
+		t.Fatalf("expected port 9999, got %d", cfg.Port)
+	}
+}
+
+func TestNewFromCLIArgsDefaultsWithoutFlags(t *testing.T) {
+	originalArgs := os.Args
+	t.Cleanup(func() {
+		os.Args = originalArgs
+	})
+
+	os.Args = []string{"plantuml-watch-server", "run"}
+
+	cfg, err := NewFromCLIArgs()
+	if err != nil {
+		t.Fatalf("NewFromCLIArgs returned error: %v", err)
+	}
+
+	expectedInput, err := filepath.Abs("input")
+	if err != nil {
+		t.Fatalf("filepath.Abs(input): %v", err)
+	}
+	expectedOutput, err := filepath.Abs("output")
+	if err != nil {
+		t.Fatalf("filepath.Abs(output): %v", err)
+	}
+
+	if cfg.PlantUMLPath != "plantuml.jar" {
+		t.Fatalf("expected default PlantUMLPath, got %q", cfg.PlantUMLPath)
+	}
+	if cfg.InputFolder != expectedInput {
+		t.Fatalf("expected input folder %q, got %q", expectedInput, cfg.InputFolder)
+	}
+	if cfg.OutputFolder != expectedOutput {
+		t.Fatalf("expected output folder %q, got %q", expectedOutput, cfg.OutputFolder)
+	}
+	if cfg.Port != 8080 {
+		t.Fatalf("expected default port 8080, got %d", cfg.Port)
+	}
+}
+
+func TestNewFromArgsHelp(t *testing.T) {
+	cfg, err := NewFromArgs([]string{"-h"})
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp, got %v", err)
+	}
+	if cfg != nil {
+		t.Fatalf("expected nil config on help, got %#v", cfg)
+	}
+}
+
+func assertConfigPaths(t *testing.T, cfg *Config, inputPath, outputPath string) {
+	t.Helper()
+
+	expectedInput, err := filepath.Abs(inputPath)
+	if err != nil {
+		t.Fatalf("filepath.Abs(%s): %v", inputPath, err)
+	}
+	expectedOutput, err := filepath.Abs(outputPath)
+	if err != nil {
+		t.Fatalf("filepath.Abs(%s): %v", outputPath, err)
+	}
+
+	if cfg.InputFolder != expectedInput {
+		t.Fatalf("expected input folder %q, got %q", expectedInput, cfg.InputFolder)
+	}
+	if cfg.OutputFolder != expectedOutput {
+		t.Fatalf("expected output folder %q, got %q", expectedOutput, cfg.OutputFolder)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.25.0
 
 require (
 	github.com/gorilla/websocket v1.5.3
-	github.com/platforma-dev/platforma v0.1.0-alpha.15
+	github.com/platforma-dev/platforma v0.1.0-alpha.23
 )
 
 require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/jmoiron/sqlx v1.4.0 // indirect
-	github.com/lib/pq v1.10.9 // indirect
+	github.com/lib/pq v1.11.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.11.2 h1:x6gxUeu39V0BHZiugWe8LXZYZ+Utk7hSJGThs8sdzfs=
+github.com/lib/pq v1.11.2/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
@@ -80,6 +82,8 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/platforma-dev/platforma v0.1.0-alpha.15 h1:bQSCtILDqeX+I2+yATq0pl5vRqOzOcs+zfyBRxCj0ig=
 github.com/platforma-dev/platforma v0.1.0-alpha.15/go.mod h1:EHBtS3WhuNlO3khvR5dParCNHKNJozOqa2EugDKKRos=
+github.com/platforma-dev/platforma v0.1.0-alpha.23 h1:QaWndSZV0ThBSwEG0T6F7iW+wEzjeKDab9H0P9gv4Y0=
+github.com/platforma-dev/platforma v0.1.0-alpha.23/go.mod h1:/5YxgfljYE8aYNm3QAgTsmd1z7kHiNsq7kEVF4iXGTA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=

--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"embed"
+	"errors"
+	"flag"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -48,6 +50,9 @@ func main() {
 
 	config, err := config.NewFromCLIArgs()
 	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return
+		}
 		log.ErrorContext(ctx, "failed to load config", "error", err)
 		return
 	}


### PR DESCRIPTION
## Summary
- Adds a `run` subcommand entrypoint for starting the server from the CLI.
- Updates config parsing to read flags after `run` while preserving default values and `-h` help behavior.
- Refreshes docs, Docker entrypoint, and compose examples to use `plantuml-watch-server run`.
- Bumps `platforma` and `lib/pq` dependency versions.
- Adds tests covering flag parsing, defaults, and help handling.

## Testing
- `go test ./...`
- Verified `NewFromCLIArgs()` accepts `run -input=... -output=... -port=...`.
- Verified `-h` returns `flag.ErrHelp` and exits cleanly from `main`.
- Verified default config values remain unchanged when no flags are provided.