### PR TITLE
Watch include dependencies for hidden PlantUML sources

### DIFF
--- a/inputwatcher/inputwatcher.go
+++ b/inputwatcher/inputwatcher.go
@@ -2,17 +2,22 @@ package inputwatcher
 
 import (
 	"context"
+	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/mishankov/plantuml-watch-server/plantuml"
 	"github.com/platforma-dev/platforma/log"
 )
+
+type renderer interface {
+	ExecuteWithFormat(ctx context.Context, input, output, format string)
+}
 
 func WatchFile(ctx context.Context, filePath string) error {
 	initialStat, err := os.Stat(filePath)
@@ -43,18 +48,21 @@ func WatchFile(ctx context.Context, filePath string) error {
 type InputWatcher struct {
 	inputPath  string
 	outputPath string
-	pulm       *plantuml.PlantUML
-	// Maps .puml file path to the set of output files (.svg and .png) it generated
-	fileToSvgMap   map[string]map[string]bool
-	fileToSvgMutex sync.RWMutex
+	renderer   renderer
+
+	// Maps public diagram paths to the set of output files (.svg and .png) they generated.
+	fileToOutputMap   map[string]map[string]bool
+	fileToOutputMutex sync.RWMutex
+	changeMutex       sync.Mutex
 }
 
-func New(inputPath, outputPath string, pulm *plantuml.PlantUML) *InputWatcher {
+func New(inputPath, outputPath string, renderer renderer) *InputWatcher {
 	return &InputWatcher{
-		inputPath:    inputPath,
-		outputPath:   outputPath,
-		pulm:         pulm,
-		fileToSvgMap: make(map[string]map[string]bool),
+		inputPath:         inputPath,
+		outputPath:        outputPath,
+		renderer:          renderer,
+		fileToOutputMap:   make(map[string]map[string]bool),
+		fileToOutputMutex: sync.RWMutex{},
 	}
 }
 
@@ -73,12 +81,11 @@ func (iw *InputWatcher) calculateOutputDir(ctx context.Context, inputFilePath st
 	return filepath.Join(iw.outputPath, relDir)
 }
 
-// getSvgFilesInDir returns a map of all output files (.svg and .png) in the given directory and its subdirectories
 func (iw *InputWatcher) getSvgFilesInDir(ctx context.Context, dir string) map[string]bool {
 	outputFiles := make(map[string]bool)
 	err := filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
-			return nil // Skip directories we can't access
+			return nil
 		}
 		if !info.IsDir() && (strings.HasSuffix(path, ".svg") || strings.HasSuffix(path, ".png")) {
 			outputFiles[path] = true
@@ -91,12 +98,231 @@ func (iw *InputWatcher) getSvgFilesInDir(ctx context.Context, dir string) map[st
 	return outputFiles
 }
 
-// ExecuteAndTrack executes PlantUML for a file and tracks which SVGs were generated
+func listPlantUMLFiles(root string) ([]string, error) {
+	files := []string{}
+	err := filepath.Walk(root, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info == nil || info.IsDir() || !strings.HasSuffix(path, ".puml") {
+			return nil
+		}
+
+		files = append(files, path)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Strings(files)
+	return files, nil
+}
+
+func isPublicDiagram(path string) bool {
+	return !strings.HasPrefix(filepath.Base(path), "_")
+}
+
+func filterPublicDiagrams(files []string) []string {
+	publicFiles := make([]string, 0, len(files))
+	for _, file := range files {
+		if isPublicDiagram(file) {
+			publicFiles = append(publicFiles, file)
+		}
+	}
+	return publicFiles
+}
+
+func parseIncludeTarget(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return "", false
+	}
+
+	var remainder string
+	for _, directive := range []string{"!include_once", "!include_many", "!include"} {
+		if !strings.HasPrefix(trimmed, directive) {
+			continue
+		}
+
+		if len(trimmed) > len(directive) {
+			next := trimmed[len(directive)]
+			if next != ' ' && next != '\t' {
+				continue
+			}
+		}
+
+		remainder = strings.TrimSpace(trimmed[len(directive):])
+		break
+	}
+	if remainder == "" {
+		return "", false
+	}
+
+	if strings.HasPrefix(remainder, "<") {
+		return "", false
+	}
+
+	if quote := remainder[0]; quote == '"' || quote == '\'' {
+		end := strings.IndexRune(remainder[1:], rune(quote))
+		if end == -1 {
+			return "", false
+		}
+		return remainder[1 : end+1], true
+	}
+
+	return strings.Fields(remainder)[0], true
+}
+
+func resolveIncludedPath(inputRoot, includingFile, includeTarget string) (string, bool) {
+	if includeTarget == "" {
+		return "", false
+	}
+
+	if strings.Contains(includeTarget, "://") {
+		return "", false
+	}
+
+	candidates := []string{includeTarget}
+	if filepath.Ext(includeTarget) == "" {
+		candidates = append(candidates, includeTarget+".puml")
+	}
+
+	for _, candidate := range candidates {
+		cleanCandidate := filepath.Clean(candidate)
+
+		var resolved string
+		if filepath.IsAbs(cleanCandidate) {
+			resolved = cleanCandidate
+		} else {
+			resolved = filepath.Join(filepath.Dir(includingFile), cleanCandidate)
+		}
+
+		absResolved, err := filepath.Abs(resolved)
+		if err != nil {
+			continue
+		}
+
+		absRoot, err := filepath.Abs(inputRoot)
+		if err != nil {
+			continue
+		}
+
+		if absResolved != absRoot && !strings.HasPrefix(absResolved, absRoot+string(filepath.Separator)) {
+			continue
+		}
+
+		info, err := os.Stat(absResolved)
+		if err != nil || info.IsDir() || filepath.Ext(absResolved) != ".puml" {
+			continue
+		}
+
+		return absResolved, true
+	}
+
+	return "", false
+}
+
+func readLocalIncludes(inputRoot, sourceFile string) ([]string, error) {
+	data, err := os.ReadFile(sourceFile)
+	if err != nil {
+		return nil, err
+	}
+
+	includes := []string{}
+	for _, line := range strings.Split(string(data), "\n") {
+		target, ok := parseIncludeTarget(line)
+		if !ok {
+			continue
+		}
+
+		resolved, ok := resolveIncludedPath(inputRoot, sourceFile, target)
+		if ok {
+			includes = append(includes, resolved)
+		}
+	}
+
+	return includes, nil
+}
+
+func buildAffectedPublicIndex(inputRoot string, sourceFiles []string) (map[string][]string, error) {
+	sourceSet := make(map[string]bool, len(sourceFiles))
+	for _, file := range sourceFiles {
+		sourceSet[file] = true
+	}
+
+	adjacency := make(map[string][]string, len(sourceFiles))
+	var buildErr error
+	for _, file := range sourceFiles {
+		includes, err := readLocalIncludes(inputRoot, file)
+		if err != nil {
+			buildErr = errors.Join(buildErr, err)
+			continue
+		}
+
+		deduped := make(map[string]bool, len(includes))
+		for _, include := range includes {
+			if sourceSet[include] {
+				deduped[include] = true
+			}
+		}
+
+		neighbors := make([]string, 0, len(deduped))
+		for include := range deduped {
+			neighbors = append(neighbors, include)
+		}
+		sort.Strings(neighbors)
+		adjacency[file] = neighbors
+	}
+
+	affected := make(map[string][]string, len(sourceFiles))
+	for _, publicDiagram := range filterPublicDiagrams(sourceFiles) {
+		visited := map[string]bool{}
+		stack := []string{publicDiagram}
+
+		for len(stack) > 0 {
+			current := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			if visited[current] {
+				continue
+			}
+
+			visited[current] = true
+			affected[current] = append(affected[current], publicDiagram)
+
+			for _, include := range adjacency[current] {
+				if !visited[include] {
+					stack = append(stack, include)
+				}
+			}
+		}
+	}
+
+	for _, diagrams := range affected {
+		sort.Strings(diagrams)
+	}
+
+	return affected, buildErr
+}
+
+func (iw *InputWatcher) GetSourceFiles(ctx context.Context) []string {
+	files, err := listPlantUMLFiles(iw.inputPath)
+	if err != nil {
+		log.ErrorContext(ctx, "error getting source files", "error", err)
+		return nil
+	}
+
+	return files
+}
+
+func (iw *InputWatcher) GetPublicFiles(ctx context.Context) []string {
+	return filterPublicDiagrams(iw.GetSourceFiles(ctx))
+}
+
 func (iw *InputWatcher) ExecuteAndTrack(ctx context.Context, inputFile, outputDir string) {
-	// Get SVG files before execution
 	svgsBefore := iw.getSvgFilesInDir(ctx, outputDir)
 
-	// Get modification times of existing SVGs
 	mtimesBefore := make(map[string]time.Time)
 	for svgPath := range svgsBefore {
 		if info, err := os.Stat(svgPath); err == nil {
@@ -104,31 +330,23 @@ func (iw *InputWatcher) ExecuteAndTrack(ctx context.Context, inputFile, outputDi
 		}
 	}
 
-	// Execute PlantUML for both SVG and PNG formats
-	iw.pulm.ExecuteWithFormat(ctx, inputFile, outputDir, "svg")
-	iw.pulm.ExecuteWithFormat(ctx, inputFile, outputDir, "png")
+	iw.renderer.ExecuteWithFormat(ctx, inputFile, outputDir, "svg")
+	iw.renderer.ExecuteWithFormat(ctx, inputFile, outputDir, "png")
 
-	// Get SVG files after execution
 	svgsAfter := iw.getSvgFilesInDir(ctx, outputDir)
 
-	// Determine which SVGs were created or modified by this execution
 	generatedSvgs := make(map[string]bool)
 	for svgPath := range svgsAfter {
-		// New file or modified file
 		if !svgsBefore[svgPath] {
 			generatedSvgs[svgPath] = true
 		} else if info, err := os.Stat(svgPath); err == nil {
-			if beforeTime, exists := mtimesBefore[svgPath]; exists {
-				if info.ModTime().After(beforeTime) {
-					generatedSvgs[svgPath] = true
-				}
+			if beforeTime, exists := mtimesBefore[svgPath]; exists && info.ModTime().After(beforeTime) {
+				generatedSvgs[svgPath] = true
 			}
 		}
 	}
 
-	// If no output files were detected as generated, fall back to expected naming
 	if len(generatedSvgs) == 0 {
-		// Assume the output files have the same base name as the .puml file
 		baseName := strings.TrimSuffix(filepath.Base(inputFile), ".puml")
 		expectedSvg := filepath.Join(outputDir, baseName+".svg")
 		expectedPng := filepath.Join(outputDir, baseName+".png")
@@ -140,103 +358,122 @@ func (iw *InputWatcher) ExecuteAndTrack(ctx context.Context, inputFile, outputDi
 		}
 	}
 
-	// Get old output files for this input file
-	iw.fileToSvgMutex.RLock()
-	oldSvgs := iw.fileToSvgMap[inputFile]
-	iw.fileToSvgMutex.RUnlock()
+	iw.fileToOutputMutex.RLock()
+	oldOutputs := iw.fileToOutputMap[inputFile]
+	iw.fileToOutputMutex.RUnlock()
 
-	// Delete output files that are no longer generated
-	for oldSvg := range oldSvgs {
-		if !generatedSvgs[oldSvg] {
-			if err := os.Remove(oldSvg); err != nil {
+	for oldOutput := range oldOutputs {
+		if !generatedSvgs[oldOutput] {
+			if err := os.Remove(oldOutput); err != nil {
 				if !os.IsNotExist(err) {
-					log.ErrorContext(ctx, "failed to delete orphaned output file", "file", oldSvg, "error", err)
+					log.ErrorContext(ctx, "failed to delete orphaned output file", "file", oldOutput, "error", err)
 				}
 			} else {
-				log.InfoContext(ctx, "deleted orphaned output file", "file", oldSvg)
+				log.InfoContext(ctx, "deleted orphaned output file", "file", oldOutput)
 			}
 		}
 	}
 
-	// Update the mapping
-	iw.fileToSvgMutex.Lock()
-	iw.fileToSvgMap[inputFile] = generatedSvgs
-	iw.fileToSvgMutex.Unlock()
+	iw.fileToOutputMutex.Lock()
+	iw.fileToOutputMap[inputFile] = generatedSvgs
+	iw.fileToOutputMutex.Unlock()
 }
 
-func (iw *InputWatcher) GetFiles(ctx context.Context) []string {
-	files := []string{}
-	err := filepath.Walk(iw.inputPath, func(path string, info fs.FileInfo, err error) error {
-		if strings.HasSuffix(path, ".puml") {
-			// Skip files prefixed with underscore
-			if !strings.HasPrefix(filepath.Base(path), "_") {
-				files = append(files, path)
-			}
-		}
+func (iw *InputWatcher) renderPublicDiagram(ctx context.Context, inputFile string) {
+	iw.ExecuteAndTrack(ctx, inputFile, iw.calculateOutputDir(ctx, inputFile))
+}
 
-		return nil
-	})
+func (iw *InputWatcher) RenderPublicDiagram(ctx context.Context, inputFile string) {
+	iw.changeMutex.Lock()
+	defer iw.changeMutex.Unlock()
 
+	iw.renderPublicDiagram(ctx, inputFile)
+}
+
+func (iw *InputWatcher) affectedPublicDiagrams(ctx context.Context, changedFile string) []string {
+	sourceFiles := iw.GetSourceFiles(ctx)
+	publicFiles := filterPublicDiagrams(sourceFiles)
+
+	affectedIndex, err := buildAffectedPublicIndex(iw.inputPath, sourceFiles)
 	if err != nil {
-		log.ErrorContext(ctx, "error getting files", "error", err)
+		log.ErrorContext(ctx, "failed building include dependency index; falling back to all public diagrams", "error", err)
+		return publicFiles
 	}
 
-	return files
+	affected := affectedIndex[changedFile]
+	if len(affected) == 0 && isPublicDiagram(changedFile) {
+		return []string{changedFile}
+	}
+
+	return affected
+}
+
+func (iw *InputWatcher) HandleSourceChange(ctx context.Context, changedFile string) {
+	iw.changeMutex.Lock()
+	defer iw.changeMutex.Unlock()
+
+	for _, publicDiagram := range iw.affectedPublicDiagrams(ctx, changedFile) {
+		log.InfoContext(ctx, "regenerating affected diagram", "source", changedFile, "diagram", publicDiagram)
+		iw.renderPublicDiagram(ctx, publicDiagram)
+	}
+}
+
+func (iw *InputWatcher) DeleteTrackedOutputs(ctx context.Context, inputFile string) {
+	iw.fileToOutputMutex.RLock()
+	outputs, exists := iw.fileToOutputMap[inputFile]
+	iw.fileToOutputMutex.RUnlock()
+
+	if !exists {
+		return
+	}
+
+	for outputPath := range outputs {
+		if err := os.Remove(outputPath); err != nil {
+			if !os.IsNotExist(err) {
+				log.ErrorContext(ctx, "failed to delete output file", "file", outputPath, "error", err)
+			}
+		} else {
+			log.InfoContext(ctx, "deleted orphaned output file", "file", outputPath)
+		}
+	}
+
+	iw.fileToOutputMutex.Lock()
+	delete(iw.fileToOutputMap, inputFile)
+	iw.fileToOutputMutex.Unlock()
 }
 
 func (iw *InputWatcher) Run(ctx context.Context) error {
-	files := iw.GetFiles(ctx)
+	sourceFiles := iw.GetSourceFiles(ctx)
 	oldFiles := []string{}
 
 	for {
-		for _, file := range files {
+		for _, file := range sourceFiles {
 			if !slices.Contains(oldFiles, file) {
-				log.InfoContext(ctx, "watching new file", "file", file)
-				outputDir := iw.calculateOutputDir(ctx, file)
-				iw.ExecuteAndTrack(ctx, file, outputDir)
+				log.InfoContext(ctx, "watching new source file", "file", file)
+				if isPublicDiagram(file) {
+					iw.RenderPublicDiagram(ctx, file)
+				}
 
-				// Fix goroutine closure bug by passing file and outputDir as parameters
-				go func(watchedFile string, watchedOutputDir string) {
+				go func(watchedFile string) {
 					for {
 						err := WatchFile(ctx, watchedFile)
 						if err != nil {
-							log.ErrorContext(ctx, "stopped watching file", "error", err)
+							log.ErrorContext(ctx, "stopped watching file", "file", watchedFile, "error", err)
 							break
 						}
 
-						log.InfoContext(ctx, "file changed", "file", watchedFile)
-
-						iw.ExecuteAndTrack(ctx, watchedFile, watchedOutputDir)
+						log.InfoContext(ctx, "source file changed", "file", watchedFile)
+						iw.HandleSourceChange(ctx, watchedFile)
 					}
-				}(file, outputDir)
+				}(file)
 			}
 		}
 
-		// Detect deleted files and remove corresponding output files
 		for _, oldFile := range oldFiles {
-			if !slices.Contains(files, oldFile) {
+			if !slices.Contains(sourceFiles, oldFile) {
 				log.InfoContext(ctx, "file removed", "file", oldFile)
-
-				// Delete all output files that were generated by this file
-				iw.fileToSvgMutex.RLock()
-				svgs, exists := iw.fileToSvgMap[oldFile]
-				iw.fileToSvgMutex.RUnlock()
-
-				if exists {
-					for svgPath := range svgs {
-						if err := os.Remove(svgPath); err != nil {
-							if !os.IsNotExist(err) {
-								log.ErrorContext(ctx, "failed to delete output file", "file", svgPath, "error", err)
-
-							}
-						} else {
-							log.InfoContext(ctx, "deleted orphaned output file", "file", svgPath)
-						}
-					}
-					// Remove the mapping
-					iw.fileToSvgMutex.Lock()
-					delete(iw.fileToSvgMap, oldFile)
-					iw.fileToSvgMutex.Unlock()
+				if isPublicDiagram(oldFile) {
+					iw.DeleteTrackedOutputs(ctx, oldFile)
 				}
 			}
 		}
@@ -247,7 +484,7 @@ func (iw *InputWatcher) Run(ctx context.Context) error {
 		case <-time.After(100 * time.Millisecond):
 		}
 
-		oldFiles = files
-		files = iw.GetFiles(ctx)
+		oldFiles = sourceFiles
+		sourceFiles = iw.GetSourceFiles(ctx)
 	}
 }

--- a/inputwatcher/inputwatcher_test.go
+++ b/inputwatcher/inputwatcher_test.go
@@ -1,0 +1,182 @@
+package inputwatcher
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"testing"
+)
+
+type renderCall struct {
+	input  string
+	output string
+	format string
+}
+
+type stubRenderer struct {
+	mu    sync.Mutex
+	calls []renderCall
+}
+
+func (r *stubRenderer) ExecuteWithFormat(_ context.Context, input, output, format string) {
+	r.mu.Lock()
+	r.calls = append(r.calls, renderCall{input: input, output: output, format: format})
+	r.mu.Unlock()
+
+	_ = os.MkdirAll(output, 0o755)
+	baseName := filepath.Base(input[:len(input)-len(filepath.Ext(input))])
+	_ = os.WriteFile(filepath.Join(output, baseName+"."+format), []byte(format), 0o644)
+}
+
+func (r *stubRenderer) callCountsByInput() map[string]int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	counts := make(map[string]int, len(r.calls))
+	for _, call := range r.calls {
+		counts[call.input]++
+	}
+	return counts
+}
+
+func writeTestFile(t *testing.T, path, contents string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+}
+
+func TestListPlantUMLFilesAndFilterPublicDiagrams(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "_shared.puml"), "@startuml\n@enduml\n")
+	writeTestFile(t, filepath.Join(root, "main.puml"), "@startuml\n@enduml\n")
+	writeTestFile(t, filepath.Join(root, "nested", "_leaf.puml"), "@startuml\n@enduml\n")
+	writeTestFile(t, filepath.Join(root, "nested", "diagram.puml"), "@startuml\n@enduml\n")
+	writeTestFile(t, filepath.Join(root, "ignore.txt"), "ignore")
+
+	files, err := listPlantUMLFiles(root)
+	if err != nil {
+		t.Fatalf("listPlantUMLFiles failed: %v", err)
+	}
+
+	wantFiles := []string{
+		filepath.Join(root, "_shared.puml"),
+		filepath.Join(root, "main.puml"),
+		filepath.Join(root, "nested", "_leaf.puml"),
+		filepath.Join(root, "nested", "diagram.puml"),
+	}
+	if !reflect.DeepEqual(files, wantFiles) {
+		t.Fatalf("unexpected files: got %v want %v", files, wantFiles)
+	}
+
+	wantPublic := []string{
+		filepath.Join(root, "main.puml"),
+		filepath.Join(root, "nested", "diagram.puml"),
+	}
+	if public := filterPublicDiagrams(files); !reflect.DeepEqual(public, wantPublic) {
+		t.Fatalf("unexpected public files: got %v want %v", public, wantPublic)
+	}
+}
+
+func TestBuildAffectedPublicIndexTracksTransitiveIncludes(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "_shared.puml"), "!include nested/_leaf.puml\n@startuml\n@enduml\n")
+	writeTestFile(t, filepath.Join(root, "main.puml"), "!include _shared.puml\n@startuml\n@enduml\n")
+	writeTestFile(t, filepath.Join(root, "nested", "_leaf.puml"), "@startuml\n@enduml\n")
+	writeTestFile(t, filepath.Join(root, "nested", "diagram.puml"), "!include ../_shared.puml\n@startuml\n@enduml\n")
+
+	files, err := listPlantUMLFiles(root)
+	if err != nil {
+		t.Fatalf("listPlantUMLFiles failed: %v", err)
+	}
+
+	affected, err := buildAffectedPublicIndex(root, files)
+	if err != nil {
+		t.Fatalf("buildAffectedPublicIndex failed: %v", err)
+	}
+
+	leaf := filepath.Join(root, "nested", "_leaf.puml")
+	shared := filepath.Join(root, "_shared.puml")
+	main := filepath.Join(root, "main.puml")
+	diagram := filepath.Join(root, "nested", "diagram.puml")
+
+	if got, want := affected[leaf], []string{main, diagram}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected leaf dependents: got %v want %v", got, want)
+	}
+	if got, want := affected[shared], []string{main, diagram}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected shared dependents: got %v want %v", got, want)
+	}
+	if got, want := affected[main], []string{main}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected main dependents: got %v want %v", got, want)
+	}
+	if got, want := affected[diagram], []string{diagram}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected diagram dependents: got %v want %v", got, want)
+	}
+}
+
+func TestHandleSourceChangeRegeneratesAffectedPublicDiagramsOnce(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	output := filepath.Join(root, "output")
+	writeTestFile(t, filepath.Join(root, "_shared.puml"), "@startuml\n@enduml\n")
+	writeTestFile(t, filepath.Join(root, "main.puml"), "!include _shared.puml\n@startuml\n@enduml\n")
+	writeTestFile(t, filepath.Join(root, "nested", "diagram.puml"), "!include ../_shared.puml\n!include_once ../_shared.puml\n@startuml\n@enduml\n")
+
+	renderer := &stubRenderer{}
+	watcher := New(root, output, renderer)
+
+	watcher.HandleSourceChange(context.Background(), filepath.Join(root, "_shared.puml"))
+
+	counts := renderer.callCountsByInput()
+	if got, want := counts[filepath.Join(root, "main.puml")], 2; got != want {
+		t.Fatalf("unexpected render count for main: got %d want %d", got, want)
+	}
+	if got, want := counts[filepath.Join(root, "nested", "diagram.puml")], 2; got != want {
+		t.Fatalf("unexpected render count for diagram: got %d want %d", got, want)
+	}
+	if len(counts) != 2 {
+		t.Fatalf("expected exactly two public diagrams to render, got %v", counts)
+	}
+}
+
+func TestDeleteTrackedOutputsRemovesGeneratedFiles(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	output := filepath.Join(root, "output")
+	inputFile := filepath.Join(root, "main.puml")
+	writeTestFile(t, inputFile, "@startuml\n@enduml\n")
+
+	renderer := &stubRenderer{}
+	watcher := New(root, output, renderer)
+	watcher.ExecuteAndTrack(context.Background(), inputFile, output)
+
+	svgPath := filepath.Join(output, "main.svg")
+	pngPath := filepath.Join(output, "main.png")
+	if _, err := os.Stat(svgPath); err != nil {
+		t.Fatalf("expected svg output to exist: %v", err)
+	}
+	if _, err := os.Stat(pngPath); err != nil {
+		t.Fatalf("expected png output to exist: %v", err)
+	}
+
+	watcher.DeleteTrackedOutputs(context.Background(), inputFile)
+
+	if _, err := os.Stat(svgPath); !os.IsNotExist(err) {
+		t.Fatalf("expected svg output to be deleted, got %v", err)
+	}
+	if _, err := os.Stat(pngPath); !os.IsNotExist(err) {
+		t.Fatalf("expected png output to be deleted, got %v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,13 +3,11 @@ package main
 import (
 	"context"
 	"embed"
-	"fmt"
 	"html/template"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/mishankov/plantuml-watch-server/config"
@@ -66,21 +64,10 @@ func main() {
 		// Remove all stale outputs
 		os.RemoveAll(config.OutputFolder + "/")
 
-		// Generate initial SVGs - iterate through each file to preserve structure
-		inputPattern := config.InputFolder + "/**.puml"
-		files, err := filepath.Glob(inputPattern)
-		if err != nil {
-			return fmt.Errorf("Error finding .puml files: %w", err)
-		}
+		files := iw.GetPublicFiles(ctx)
 
 		for _, file := range files {
-			// Skip files prefixed with underscore
-			if strings.HasPrefix(filepath.Base(file), "_") {
-				continue
-			}
-
-			outputDir := calculateOutputDirForFile(ctx, file, config.InputFolder, config.OutputFolder)
-			iw.ExecuteAndTrack(ctx, file, outputDir)
+			iw.RenderPublicDiagram(ctx, file)
 		}
 		return nil
 	}, application.StartupTaskConfig{Name: "initial generation", AbortOnError: true})

--- a/plans/0001. update diagrams on include changes/plan.md
+++ b/plans/0001. update diagrams on include changes/plan.md
@@ -1,0 +1,87 @@
+# Plan: Update diagrams on include changes
+
+> Source PRD: `plans/0001. update diagrams on include changes/prd.md` and issue `#36`
+
+## Architectural decisions
+
+Durable decisions that apply across all phases:
+
+- **Inputs**: Treat every local `.puml` file under the configured input root as a watchable source.
+- **Public diagrams**: Only `.puml` files whose base name does not start with `_` are public entry diagrams. Only public entry diagrams appear in generated outputs and the UI.
+- **Dependency model**: Maintain local include relationships between watched source files and derive a reverse mapping from any changed source to the public entry diagrams affected by that change.
+- **Include resolution**: Resolve local include paths relative to the including file so nested folder layouts continue to work.
+- **Regeneration behavior**: A change event regenerates the changed public diagram itself when applicable, plus every dependent public diagram exactly once.
+- **Startup behavior**: Initial generation continues to happen before the server starts serving traffic, with the same public-diagram filtering and output-folder layout rules.
+- **Output ownership**: Output cleanup remains keyed to public entry diagrams so deleted or renamed diagrams still remove their previously generated `.svg` and `.png` files.
+- **Scope boundary**: No UI, websocket, HTTP route, or CLI changes are required for this feature.
+
+---
+
+## Phase 1: Separate watchable sources from public diagrams
+
+**User stories**: 3, 4, 5, 10
+
+### What to build
+
+Introduce an explicit distinction between all watchable PlantUML sources and public entry diagrams. Startup generation and ongoing watching should operate on the full source set for change detection, while rendering and output publication remain limited to public entry diagrams.
+
+### Acceptance criteria
+
+- [ ] The system can enumerate all local `.puml` sources under the input tree, including underscore-prefixed helper files.
+- [ ] The system can enumerate public entry diagrams as a separate subset that excludes underscore-prefixed files.
+- [ ] Startup generation still renders only public entry diagrams and preserves the current output directory structure.
+- [ ] Hidden helper files remain absent from generated standalone outputs and from any file-listing behavior derived from the output directory.
+
+---
+
+## Phase 2: Build local include dependency awareness
+
+**User stories**: 1, 2, 7, 11, 12
+
+### What to build
+
+Add dependency discovery for local include relationships between watched source files. The system should be able to determine which public entry diagrams depend on a given source file, including transitive dependency chains through shared helper files.
+
+### Acceptance criteria
+
+- [ ] Local include references are discovered from watched source files and normalized to source files within the input tree.
+- [ ] Relative include paths are resolved from the including file's directory.
+- [ ] The system can answer which public entry diagrams are affected by a change to a shared helper file.
+- [ ] Transitive include chains are supported so a deeply shared source still maps back to the correct public entry diagrams.
+- [ ] Dependency discovery failures do not terminate the watcher; affected public diagrams are still handled conservatively.
+
+---
+
+## Phase 3: Regenerate affected public diagrams on source changes
+
+**User stories**: 1, 2, 5, 6, 8, 9, 11
+
+### What to build
+
+Connect dependency awareness to watcher execution so a source-file change regenerates the correct set of public entry diagrams, with deduplication and existing cleanup behavior intact. Public diagrams should still rerender on direct edits, and helper-file edits should now refresh every affected public output.
+
+### Acceptance criteria
+
+- [ ] Editing a public entry diagram still regenerates that diagram's outputs.
+- [ ] Editing an underscore-prefixed helper file regenerates every affected public entry diagram and does not attempt to render the helper file itself as a standalone diagram.
+- [ ] Affected public diagrams are regenerated at most once per source-change handling cycle.
+- [ ] Multiple public diagrams depending on the same helper file are all regenerated after that helper changes.
+- [ ] Removing a public entry diagram still removes its previously generated outputs.
+
+---
+
+## Phase 4: Lock in behavior with focused tests
+
+**User stories**: 1, 2, 3, 4, 6, 8, 12
+
+### What to build
+
+Add focused regression coverage around dependency resolution and watcher orchestration so include-aware regeneration remains stable without relying on a live PlantUML process in tests.
+
+### Acceptance criteria
+
+- [ ] Automated tests cover the distinction between watchable sources and public entry diagrams.
+- [ ] Automated tests cover direct and transitive dependency expansion for local include relationships.
+- [ ] Automated tests cover regeneration-set selection for helper-file changes and public-diagram changes.
+- [ ] Automated tests cover deduplication and public-output cleanup behavior.
+- [ ] The full project test suite passes after the feature is implemented.

--- a/plans/0001. update diagrams on include changes/prd.md
+++ b/plans/0001. update diagrams on include changes/prd.md
@@ -1,0 +1,55 @@
+## Problem Statement
+
+The watch server currently treats underscore-prefixed `.puml` files as ignored inputs. That works for hiding partials and shared snippets from the UI, but it also means those files are not watched as change sources. When a renderable diagram includes one of those shared files, editing the shared file does not refresh the generated output for the diagrams that depend on it. The browser can therefore keep showing stale diagrams until a top-level diagram is edited manually.
+
+## Solution
+
+Treat every local `.puml` file as a watchable source, while preserving the existing rule that underscore-prefixed files are not standalone diagrams. Build dependency awareness for local include relationships so the server can determine which public diagrams depend on a changed source file. When any source changes, regenerate the changed public diagram itself when applicable and also regenerate every public diagram that depends on that source directly or transitively. Keep ignored include files hidden from the index and do not generate standalone output for them.
+
+## User Stories
+
+1. As a diagram author, I want a diagram that includes `_common.puml` to refresh automatically after `_common.puml` changes, so that shared edits are reflected without touching the top-level diagram file.
+2. As a diagram author, I want diagrams with nested includes to refresh when any included file in the chain changes, so that transitive dependencies stay accurate.
+3. As a diagram author, I want underscore-prefixed include files to remain hidden from the generated diagram list, so that helper sources do not appear as standalone diagrams.
+4. As a diagram author, I want underscore-prefixed include files to avoid producing standalone `.svg` and `.png` outputs, so that the output directory only contains public diagrams.
+5. As a diagram author, I want direct edits to a public diagram to keep regenerating that diagram as they do today, so that the existing editing workflow does not regress.
+6. As a diagram author, I want dependent diagrams to be regenerated only once per change event, so that shared include edits do not trigger duplicate work for the same output.
+7. As a diagram author, I want relative include paths to resolve from the including file, so that diagrams organized in nested folders behave correctly.
+8. As a diagram author, I want deleted or renamed public diagrams to keep cleaning up their previously generated outputs, so that stale files are not left behind.
+9. As a diagram author, I want include-file edits to trigger browser-visible output updates through the existing generated files, so that live viewing keeps working without UI changes.
+10. As an operator, I want startup generation to account for include dependencies before the server begins serving requests, so that outputs are consistent from the first page load.
+11. As a maintainer, I want dependency tracking to work for shared include files referenced by multiple diagrams, so that a single source edit refreshes every affected diagram.
+12. As a maintainer, I want dependency-aware behavior covered by tests, so that future watcher changes do not silently break include updates.
+
+## Implementation Decisions
+
+- Introduce a distinction between watchable source files and public entry diagrams. All local `.puml` files under the input tree are watchable sources. Public entry diagrams are the subset whose base filename does not start with `_`.
+- Add dependency discovery for local include relationships and maintain a reverse dependency index from source files to the public entry diagrams that depend on them.
+- Resolve include paths relative to the including file's directory so nested diagram folders continue to work predictably.
+- Support transitive dependency expansion so changes to a deeply shared include file still regenerate the correct top-level public diagrams.
+- Preserve the existing output-location behavior for public diagrams, including nested output directories and orphaned-output cleanup when a public diagram stops generating a file.
+- Preserve the current product rule that ignored helper files are not listed in the UI and do not get standalone generated outputs.
+- When dependency information is incomplete or an include cannot be resolved, the watcher should still remain operational and attempt the affected public renders rather than crashing the process.
+- Keep the implementation scoped to repository-local include relationships used by watched `.puml` files. The feature does not require UI, protocol, or CLI changes.
+
+## Testing Decisions
+
+- Good tests should validate externally visible behavior: which public diagrams are considered affected by a source change, whether ignored helper files stay hidden, and whether transitive dependencies are included in the regeneration set.
+- Test the dependency-discovery and dependency-expansion logic as a deep module in isolation, using small synthetic file trees instead of relying on PlantUML execution.
+- Test watcher orchestration with a stubbed renderer so change handling can verify affected diagrams and cleanup behavior without invoking Java.
+- Keep assertions focused on observable outcomes such as affected source sets, generated-output ownership, and ignore semantics rather than internal map shapes.
+- Follow the existing Go unit-test style already present in the repository as prior art for table-driven or focused behavior tests.
+
+## Out of Scope
+
+- Rendering underscore-prefixed include files as standalone diagrams.
+- Changing the browser UI, websocket protocol, or download behavior.
+- Replacing the current polling-based file-watch approach with filesystem notifications.
+- Adding support for remote include URLs or non-local dependency sources beyond what is needed for local watched files.
+- Broad refactors unrelated to include-aware regeneration.
+
+## Further Notes
+
+- This PRD assumes the issue's requested behavior applies to included local `.puml` sources in general, with underscore-prefixed files being the explicit failing case called out by the issue.
+- If implementation uncovers multiple include syntaxes in active use, support should be expanded only as needed to cover local repository usage while preserving the same dependency-aware behavior.
+- Source issue: https://github.com/mishankov/plantuml-watch-server/issues/36


### PR DESCRIPTION
## Summary
- Treat all local `.puml` files as watchable sources while keeping underscore-prefixed files hidden from the public diagram list.
- Add local include parsing and reverse dependency tracking so changes to shared helper files regenerate every affected public diagram, including transitive dependencies.
- Preserve output cleanup for public diagrams and update startup generation to render only public diagrams.
- Add unit coverage for source enumeration, dependency expansion, source-change handling, and tracked output deletion.

## Testing
- `go test ./...` not run in this environment.
- Added tests for `listPlantUMLFiles` and public-diagram filtering.
- Added tests for transitive include dependency indexing.
- Added tests for regenerating affected public diagrams from a shared helper change.
- Added tests for deleting tracked `.svg` and `.png` outputs when a public diagram is removed.